### PR TITLE
Add runtime backend switching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Guidelines
+
+- Always format Go code with `gofmt -w` on changed files.
+- Run `go test ./...` and ensure all tests pass after modifying code.
+- When editing documentation only, tests are not required.
+- Keep `plan.md` updated with checkmarks for completed items and record any
+  architectural decisions that influence future work.
+- Document new functions and exported types using Go doc comments.
+- CLI-based backends (Codex and Claude) should execute the given binary using
+  `exec.CommandContext` and set `COLUMNS` and `LINES` environment variables to
+  small values so output fits within the TUI.
+- Familiarity tips: use `grep -n` and `sed -n` for quick context, and keep tests
+  fast by focusing on unit-level coverage.
+
+_Last updated: 2025-06-22_

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # AI Shell Scaffold
 
 Tiny Bubble Tea TUI that lets you flip between a normal bash prompt **and** an AI prompt.
-The AI can suggest commands, which you can approve or reject.  
+The AI can suggest commands, which you can approve or reject.
+Switch between LLM backends at runtime using the navigation keys.
 Back‑end is swappable:
 
-* **OpenAI‑compatible** (`--backend openai`) – api.openai.com, LocalAI, vLLM, Groq…  
+* **OpenAI‑compatible** (`--backend openai`) – api.openai.com, LocalAI, vLLM, Groq…
 * **Local Operator** (`--backend localop`) – any running `local-operator serve` instance.
+* **Codex CLI** (`--backend codex`) – invokes the `codex` command via stdio.
+* **Claude Code** (`--backend claude`) – invokes the `claude` command via stdio.
 
 ## Quick start
 
@@ -13,6 +16,14 @@ Back‑end is swappable:
 git clone https://github.com/you/ai-shell.git
 cd ai-shell
 go run . --backend openai --model gpt-4o
+```
+
+or to use Codex or Claude CLI (requires the binaries on PATH)
+
+```bash
+go run . --backend codex --model default
+# or
+go run . --backend claude --model default
 ```
 
 or
@@ -29,6 +40,10 @@ Keybinds:
 | `Ctrl+T`     | Toggle AI ↔ Bash    |
 | `Enter`      | Send prompt / run   |
 | `Ctrl+C` `q` | Quit                |
+| `F1`         | Use OpenAI backend  |
+| `F2`         | Use LocalOp backend |
+| `F3`         | Use Codex backend   |
+| `F4`         | Use Claude backend  |
 
 ## Files
 

--- a/llm/cliclient.go
+++ b/llm/cliclient.go
@@ -1,0 +1,76 @@
+package llm
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// cliClient implements Client by invoking an external command and
+// streaming its stdout.
+type cliClient struct {
+	path string
+}
+
+// newCLIClient returns a Client that runs the specified executable.
+func newCLIClient(path string) Client {
+	return &cliClient{path: path}
+}
+
+func (c *cliClient) Stream(ctx context.Context, hist []Message) <-chan Chunk {
+	out := make(chan Chunk, 8)
+	go func() {
+		defer close(out)
+
+		if c.path == "" {
+			out <- Chunk{Err: io.EOF}
+			return
+		}
+
+		cmd := exec.CommandContext(ctx, c.path)
+		cmd.Env = append(os.Environ(), "COLUMNS=80", "LINES=20")
+
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			out <- Chunk{Err: err}
+			return
+		}
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			out <- Chunk{Err: err}
+			return
+		}
+		cmd.Stderr = cmd.Stdout
+
+		if err := cmd.Start(); err != nil {
+			out <- Chunk{Err: err}
+			return
+		}
+
+		var prompt string
+		if len(hist) > 0 {
+			prompt = hist[len(hist)-1].Content
+		}
+		io.WriteString(stdin, prompt)
+		stdin.Close()
+
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			out <- Chunk{Text: scanner.Text()}
+		}
+		if err := scanner.Err(); err != nil {
+			out <- Chunk{Err: err}
+		}
+		cmd.Wait()
+		out <- Chunk{Done: true}
+	}()
+	return out
+}
+
+// NewCodexCLI wraps the `codex` command line tool as a Client.
+func NewCodexCLI(path string) Client { return newCLIClient(path) }
+
+// NewClaudeCode wraps the `claude` command line tool as a Client.
+func NewClaudeCode(path string) Client { return newCLIClient(path) }

--- a/llm/cliclient_test.go
+++ b/llm/cliclient_test.go
@@ -1,0 +1,36 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCLIClient(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "echo.sh")
+	script := "#!/bin/sh\nread line\necho $line processed"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newCLIClient(scriptPath)
+	hist := []Message{{Role: "user", Content: "test"}}
+	chunks := collectChunks(client.Stream(context.Background(), hist))
+	if len(chunks) == 0 {
+		t.Fatalf("no chunks returned")
+	}
+	if chunks[0].Text != "test processed" {
+		t.Fatalf("unexpected output: %q", chunks[0].Text)
+	}
+}
+
+// collectChunks is copied from mock_test.go
+func collectChunks(ch <-chan Chunk) []Chunk {
+	var out []Chunk
+	for c := range ch {
+		out = append(out, c)
+	}
+	return out
+}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,22 @@
+# Development Plan
+
+## Completed
+- [x] Reviewed repository structure and existing LLM backends.
+- [x] Drafted plan to support Codex CLI and Claude code.
+- [x] Added runtime backend switching with F1–F4 keys and navigation bar.
+
+## Todo
+- [ ] Add AI-assisted typeahead suggestions with a small distilled model.
+- [ ] Improve markdown editing capabilities.
+
+## Architectural Notes
+The application uses a pluggable backend interface (`llm.Client`) which streams
+`Chunk` structs to the TUI. New backends should conform to this interface.
+Codex CLI can be invoked as an external command and wrapped in a client that
+parses its output into `Chunk` messages. Claude would likely require an HTTP
+client similar to the OpenAI implementation. The CLI clients run subprocesses
+with `COLUMNS` and `LINES` environment variables set to fit inside the TUI
+panes, passing conversation prompts via standard input and streaming standard
+output lines back to the model.
+Backends are now stored in a map and can be switched at runtime; a navigation bar
+shows F-key assignments and a footer lists Ctrl-based shortcuts.

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,25 @@
+# Outstanding Tasks
+
+1. **Implement Codex CLI Backend**
+   - [x] Wrap the CLI in an `llm.Client` implementation.
+   - [x] Stream stdout lines as `Chunk.Text`.
+
+2. **Add Claude Backend**
+   - [x] Implement CLI client using the `claude` binary.
+
+3. **CLI Integration**
+   - [x] Extend `main.go` to support `--backend codex` and `--backend claude` options.
+
+4. **Testing**
+   - [x] Add unit tests for the new clients using test binaries.
+
+5. **Documentation**
+   - [x] Update the README with setup instructions for the new backends.
+
+6. **Runtime Backend Switching**
+   - [x] Add navigation menu with F1–F4 keys to switch between OpenAI, LocalOp, Codex and Claude.
+   - [x] Display Ctrl-key shortcuts at the bottom of the window.
+
+7. **Future Enhancements**
+   - [ ] Implement AI-assisted typeahead suggestions using a small distilled model.
+   - [ ] Improve markdown editing workflow within the TUI.


### PR DESCRIPTION
## Summary
- support switching backends with F1–F4 keys
- display navigation header and key help footer
- update docs and plans for new behaviour
- record quick-start notes for contributors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68587f1fc1ec8328a4d74a30fab1a0c1